### PR TITLE
Fix test failures and add coverage for recent features

### DIFF
--- a/docs/plans/plan_bugfix-fix-tests-and-add-coverage_implimentation.md
+++ b/docs/plans/plan_bugfix-fix-tests-and-add-coverage_implimentation.md
@@ -1,0 +1,37 @@
+# WIP: Fix Tests and Add Coverage
+
+**Branch:** `bugfix/fix-tests-and-add-coverage`
+**Started:** 2026-02-17
+**Status:** In Progress
+
+## Plan
+
+### Tasks
+
+- [ ] Fix vitest config to exclude e2e tests
+- [ ] Fix e2e project-discovery tests (`.badge` → `.ui-badge`, subagent collapsed check)
+- [ ] Fix e2e message-stream tests (`token-usage-bar` → `status-bar`)
+- [ ] Add data-testid to ThemeToggle component
+- [ ] Extract pure renderer utilities into testable modules
+- [ ] Add unit tests for tool formatting (MCP name parsing, icons)
+- [ ] Add unit tests for system-reminder parsing
+- [ ] Add unit tests for project sorting and activity levels
+- [ ] Add unit tests for session status detection
+- [ ] Add unit tests for StatusBar number formatting
+
+## Progress Log
+
+### 2026-02-17T20:45
+- Started work. Branch created from `dev` at `6b2a718`.
+
+## Decisions & Notes
+
+- CI runs vitest (unit + integration) and Playwright (e2e) separately — the vitest config just needs e2e excluded
+- E2e failures stem from Radix migration (`.badge` → `.ui-badge`), StatusBar replacing TokenUsageBar (`status-bar` not `token-usage-bar`), and subagents inside collapsed Radix Collapsible
+- Pure functions in renderer components will be extracted to `src/renderer/src/utils/` for testability without React deps
+
+## Blockers
+
+None currently.
+
+## Commits

--- a/docs/plans/plan_bugfix-fix-tests-and-add-coverage_implimentation.md
+++ b/docs/plans/plan_bugfix-fix-tests-and-add-coverage_implimentation.md
@@ -2,36 +2,50 @@
 
 **Branch:** `bugfix/fix-tests-and-add-coverage`
 **Started:** 2026-02-17
-**Status:** In Progress
+**Status:** Complete
 
 ## Plan
 
 ### Tasks
 
-- [ ] Fix vitest config to exclude e2e tests
-- [ ] Fix e2e project-discovery tests (`.badge` → `.ui-badge`, subagent collapsed check)
-- [ ] Fix e2e message-stream tests (`token-usage-bar` → `status-bar`)
-- [ ] Add data-testid to ThemeToggle component
-- [ ] Extract pure renderer utilities into testable modules
-- [ ] Add unit tests for tool formatting (MCP name parsing, icons)
-- [ ] Add unit tests for system-reminder parsing
-- [ ] Add unit tests for project sorting and activity levels
-- [ ] Add unit tests for session status detection
-- [ ] Add unit tests for StatusBar number formatting
+- [x] Fix vitest config to exclude e2e tests
+- [x] Fix e2e project-discovery tests (`.badge` → `.ui-badge`, subagent collapsed check)
+- [x] Fix e2e message-stream tests (`token-usage-bar` → `status-bar`)
+- [x] Add data-testid to ThemeToggle component
+- [x] Extract pure renderer utilities into testable modules
+- [x] Add unit tests for tool formatting (MCP name parsing, icons)
+- [x] Add unit tests for system-reminder parsing
+- [x] Add unit tests for project sorting and activity levels
+- [x] Add unit tests for session status detection
+- [x] Add unit tests for StatusBar number formatting
+- [x] Add e2e test for theme toggle feature
 
 ## Progress Log
 
 ### 2026-02-17T20:45
 - Started work. Branch created from `dev` at `6b2a718`.
 
+### 2026-02-17T20:47
+- Fixed vitest config, e2e selectors, committed `d1b3d76`.
+- Extracted pure utils from components, added testids to ThemeToggle, committed `9d2cb74`.
+- Added 79 new unit tests across 4 test files, committed `ee6cca5`.
+- Added e2e theme toggle tests, committed `91ec4e3`.
+- All 160 unit/integration tests passing. Ready for PR.
+
 ## Decisions & Notes
 
 - CI runs vitest (unit + integration) and Playwright (e2e) separately — the vitest config just needs e2e excluded
 - E2e failures stem from Radix migration (`.badge` → `.ui-badge`), StatusBar replacing TokenUsageBar (`status-bar` not `token-usage-bar`), and subagents inside collapsed Radix Collapsible
-- Pure functions in renderer components will be extracted to `src/renderer/src/utils/` for testability without React deps
+- Pure functions in renderer components extracted to `src/renderer/src/utils/` for testability without React deps
+- No new dependencies added — all tests use vitest and Playwright which are already installed
 
 ## Blockers
 
-None currently.
+None.
 
 ## Commits
+edc8135 - wip: start bugfix/fix-tests-and-add-coverage — init progress tracker
+d1b3d76 - fix: resolve all test failures
+9d2cb74 - refactor: extract pure utilities from renderer components for testability
+ee6cca5 - test: add unit tests for recent renderer features
+91ec4e3 - test: add e2e tests for theme toggle feature

--- a/src/renderer/src/components/ProjectList.tsx
+++ b/src/renderer/src/components/ProjectList.tsx
@@ -1,6 +1,7 @@
 import { useState, useMemo, useEffect, useCallback } from 'react'
 import { useProjects } from '../hooks/queries'
 import { Badge } from './ui/badge'
+import { sortProjects, getActivityLevel, formatRelativeTime } from '../utils/project-utils'
 import type { ProjectSortOrder } from '../../../preload/index.d'
 
 interface Project {
@@ -10,21 +11,6 @@ interface Project {
   pathVerified: boolean
   sessionCount: number
   lastModified: number
-}
-
-function formatRelativeTime(timestamp: number): string {
-  if (!timestamp) return 'Never'
-  const now = Date.now()
-  const diff = now - timestamp
-  const minutes = Math.floor(diff / 60000)
-  if (minutes < 1) return 'Just now'
-  if (minutes < 60) return `${minutes}m ago`
-  const hours = Math.floor(minutes / 60)
-  if (hours < 24) return `${hours}h ago`
-  const days = Math.floor(hours / 24)
-  if (days < 7) return `${days}d ago`
-  const date = new Date(timestamp)
-  return date.toLocaleDateString(undefined, { day: 'numeric', month: 'short', year: date.getFullYear() !== new Date().getFullYear() ? 'numeric' : undefined })
 }
 
 interface ProjectListProps {
@@ -110,26 +96,6 @@ const SORT_LABELS: Record<ProjectSortOrder, string> = {
 }
 
 const SORT_OPTIONS: ProjectSortOrder[] = ['recent', 'alpha', 'sessions']
-
-function sortProjects(projects: Project[], order: ProjectSortOrder): Project[] {
-  const sorted = [...projects]
-  switch (order) {
-    case 'alpha':
-      return sorted.sort((a, b) => a.name.localeCompare(b.name))
-    case 'recent':
-      return sorted.sort((a, b) => b.lastModified - a.lastModified)
-    case 'sessions':
-      return sorted.sort((a, b) => b.sessionCount - a.sessionCount)
-  }
-}
-
-function getActivityLevel(timestamp: number): 'active' | 'recent' | 'stale' {
-  if (!timestamp) return 'stale'
-  const diff = Date.now() - timestamp
-  if (diff < 60_000) return 'active'
-  if (diff < 300_000) return 'recent'
-  return 'stale'
-}
 
 export function ProjectList({ onProjectSelect, themeToggle }: ProjectListProps) {
   const { data: projects = [], isLoading: loading } = useProjects()

--- a/src/renderer/src/components/ProjectList.tsx
+++ b/src/renderer/src/components/ProjectList.tsx
@@ -177,6 +177,7 @@ export function ProjectList({ onProjectSelect, themeToggle }: ProjectListProps) 
       <div className="panel-content">
         <div className="project-panel-header">
           <h5 className="panel-title">Projects</h5>
+          {themeToggle}
         </div>
         <p className="panel-muted">Loading...</p>
       </div>
@@ -188,6 +189,7 @@ export function ProjectList({ onProjectSelect, themeToggle }: ProjectListProps) 
       <div className="panel-content">
         <div className="project-panel-header">
           <h5 className="panel-title">Projects</h5>
+          {themeToggle}
         </div>
         <p className="panel-muted">No projects found</p>
       </div>

--- a/src/renderer/src/components/SessionList.tsx
+++ b/src/renderer/src/components/SessionList.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useMemo } from 'react'
 import { useSessions } from '../hooks/queries'
 import { Badge } from './ui/badge'
 import { Collapsible, CollapsibleContent } from './ui/collapsible'
+import { getSessionStatus, getStatusBadge, formatDateTime } from '../utils/session-utils'
 
 interface Session {
   id: string
@@ -16,39 +17,6 @@ interface Session {
 interface SessionListProps {
   projectEncodedName: string | null
   onSessionSelect?: (filePath: string) => void
-}
-
-type SessionStatus = 'active' | 'recent' | 'stale'
-
-function getSessionStatus(lastModified: number): SessionStatus {
-  const now = Date.now()
-  const diff = now - lastModified
-  if (diff < 60 * 1000) return 'active'
-  if (diff < 5 * 60 * 1000) return 'recent'
-  return 'stale'
-}
-
-function getStatusBadge(status: SessionStatus): { icon: string; variant: 'success' | 'info' | 'secondary' } {
-  switch (status) {
-    case 'active': return { icon: '🟢', variant: 'success' }
-    case 'recent': return { icon: '🔵', variant: 'info' }
-    case 'stale': return { icon: '⚪', variant: 'secondary' }
-  }
-}
-
-function formatDateTime(timestamp: number): string {
-  const date = new Date(timestamp)
-  const now = new Date()
-  const isToday = date.toDateString() === now.toDateString()
-  const yesterday = new Date(now)
-  yesterday.setDate(yesterday.getDate() - 1)
-  const isYesterday = date.toDateString() === yesterday.toDateString()
-
-  const time = date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
-
-  if (isToday) return `Today ${time}`
-  if (isYesterday) return `Yesterday ${time}`
-  return date.toLocaleDateString([], { month: 'short', day: 'numeric' }) + ` ${time}`
 }
 
 export function SessionList({ projectEncodedName, onSessionSelect }: SessionListProps) {

--- a/src/renderer/src/components/ThemeToggle.tsx
+++ b/src/renderer/src/components/ThemeToggle.tsx
@@ -13,7 +13,7 @@ const MODES: { value: ThemeMode; label: string; title: string }[] = [
 
 export function ThemeToggle({ mode, onModeChange }: ThemeToggleProps) {
   return (
-    <div className="theme-toggle" title={`Theme: ${mode}`}>
+    <div className="theme-toggle" data-testid="theme-toggle" title={`Theme: ${mode}`}>
       {MODES.map(({ value, label, title }) => (
         <button
           key={value}
@@ -21,6 +21,7 @@ export function ThemeToggle({ mode, onModeChange }: ThemeToggleProps) {
           onClick={() => onModeChange(value)}
           title={title}
           aria-label={`${title} theme`}
+          data-testid={`theme-${value}`}
         >
           {label}
         </button>

--- a/src/renderer/src/components/messages/AssistantMessage.tsx
+++ b/src/renderer/src/components/messages/AssistantMessage.tsx
@@ -5,6 +5,7 @@ import { ToolCallCard } from './ToolCallCard'
 import type { ToolUseBlock, ToolResultContent, TokenUsage } from '../../../../main/types'
 import { Card, CardContent } from '../ui/card'
 import { Badge } from '../ui/badge'
+import { formatTokens } from '../../utils/format-utils'
 
 interface ToolPair {
   toolUse: ToolUseBlock
@@ -61,12 +62,6 @@ export function AssistantMessage({ model, textContent, toolPairs, usage, timesta
       </CardContent>
     </Card>
   )
-}
-
-function formatTokens(n: number): string {
-  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`
-  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`
-  return String(n)
 }
 
 function getRelativeTime(timestamp: string): string {

--- a/src/renderer/src/components/messages/StatusBar.tsx
+++ b/src/renderer/src/components/messages/StatusBar.tsx
@@ -1,14 +1,9 @@
 import type { TokenUsage } from '../../../../main/types'
+import { formatNum } from '../../utils/format-utils'
 
 interface StatusBarProps {
   usage: TokenUsage
   messageCount: number
-}
-
-function formatNum(n: number): string {
-  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`
-  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`
-  return n.toLocaleString()
 }
 
 export function StatusBar({ usage, messageCount }: StatusBarProps) {

--- a/src/renderer/src/components/messages/ToolCallCard.tsx
+++ b/src/renderer/src/components/messages/ToolCallCard.tsx
@@ -3,6 +3,7 @@ import hljs from 'highlight.js'
 import { Card, CardContent } from '../ui/card'
 import { Button } from '../ui/button'
 import { Collapsible, CollapsibleContent } from '../ui/collapsible'
+import { TOOL_ICONS, formatToolName, parseSystemReminders, getLangFromPath } from '../../utils/tool-formatting'
 
 interface ToolCallCardProps {
   toolName: string
@@ -16,129 +17,6 @@ function extractToolResultText(content: string | Array<{ type: string; text: str
     return content.map(block => block.text || '').join('\n')
   }
   return String(content)
-}
-
-interface ParsedResult {
-  mainContent: string
-  systemReminders: string[]
-}
-
-/** Parse out <system-reminder> tags from result text */
-function parseSystemReminders(text: string): ParsedResult {
-  const systemReminders: string[] = []
-  const reminderRegex = /<system-reminder>([\s\S]*?)<\/system-reminder>/g
-
-  let match
-  let lastIndex = 0
-  const contentParts: string[] = []
-
-  while ((match = reminderRegex.exec(text)) !== null) {
-    // Add content before this reminder
-    contentParts.push(text.slice(lastIndex, match.index))
-    // Store the reminder content
-    systemReminders.push(match[1].trim())
-    lastIndex = match.index + match[0].length
-  }
-
-  // Add any remaining content after the last reminder
-  contentParts.push(text.slice(lastIndex))
-
-  const mainContent = contentParts.join('').trim()
-
-  return { mainContent, systemReminders }
-}
-
-const TOOL_ICONS: Record<string, string> = {
-  Read: '📄',
-  Write: '✏️',
-  Edit: '🔧',
-  Bash: '💻',
-  Grep: '🔍',
-  Glob: '📁',
-  WebSearch: '🌐',
-  WebFetch: '🌐',
-  Task: '📋',
-  AskUserQuestion: '❓',
-  NotebookEdit: '📓',
-  TodoWrite: '✅',
-  // MCP server tools
-  take_screenshot: '📸',
-  take_snapshot: '🌲',
-  navigate_page: '🧭',
-  click: '🖱️',
-  fill: '⌨️',
-  fill_form: '📝',
-  evaluate_script: '⚡',
-  list_pages: '📑',
-  list_network_requests: '🌐',
-  list_console_messages: '🖥️',
-  get_network_request: '📡',
-  get_console_message: '💬',
-  hover: '🖱️',
-  press_key: '⌨️',
-  wait_for: '⏳',
-  handle_dialog: '💬',
-  performance_start_trace: '⏱️',
-  performance_stop_trace: '⏹️',
-  upload_file: '📤',
-}
-
-/** Format a tool name for display — handles MCP double-underscore names */
-function formatToolName(rawName: string): { icon: string; label: string; server?: string } {
-  const icon = TOOL_ICONS[rawName] || '🔧'
-
-  // MCP tools: mcp__server-name__tool_name
-  if (rawName.includes('__')) {
-    const parts = rawName.split('__')
-    if (parts.length >= 3) {
-      const server = parts[1]
-      const tool = parts.slice(2).join('__')
-      const toolIcon = TOOL_ICONS[tool] || icon
-      // Convert snake_case to readable label
-      const label = tool.replace(/_/g, ' ')
-      return { icon: toolIcon, label, server }
-    }
-  }
-
-  return { icon, label: rawName }
-}
-
-/** Map file extensions to highlight.js language names */
-const EXT_TO_LANG: Record<string, string> = {
-  js: 'javascript', jsx: 'javascript', mjs: 'javascript', cjs: 'javascript',
-  ts: 'typescript', tsx: 'typescript', mts: 'typescript',
-  py: 'python', rb: 'ruby', rs: 'rust', go: 'go',
-  java: 'java', kt: 'kotlin', scala: 'scala',
-  c: 'c', h: 'c', cpp: 'cpp', cc: 'cpp', cxx: 'cpp', hpp: 'cpp',
-  cs: 'csharp', swift: 'swift', m: 'objectivec',
-  sh: 'bash', bash: 'bash', zsh: 'bash', fish: 'shell',
-  html: 'xml', htm: 'xml', xml: 'xml', svg: 'xml', xsl: 'xml',
-  css: 'css', scss: 'scss', sass: 'scss', less: 'less',
-  json: 'json', yaml: 'yaml', yml: 'yaml', toml: 'ini',
-  md: 'markdown', markdown: 'markdown',
-  sql: 'sql', graphql: 'graphql', gql: 'graphql',
-  dockerfile: 'dockerfile', docker: 'dockerfile',
-  makefile: 'makefile', cmake: 'cmake',
-  lua: 'lua', perl: 'perl', pl: 'perl', php: 'php',
-  r: 'r', R: 'r', jl: 'julia',
-  hs: 'haskell', erl: 'erlang', ex: 'elixir', exs: 'elixir',
-  clj: 'clojure', lisp: 'lisp', el: 'lisp',
-  vim: 'vim', ini: 'ini', conf: 'ini', cfg: 'ini',
-  tf: 'hcl', hcl: 'hcl',
-  proto: 'protobuf', ps1: 'powershell',
-  diff: 'diff', patch: 'diff'
-}
-
-function getLangFromPath(filePath: string): string | null {
-  const fileName = filePath.split('/').pop() || ''
-  // Handle extensionless names like Dockerfile, Makefile
-  const lowerName = fileName.toLowerCase()
-  if (lowerName === 'dockerfile') return 'dockerfile'
-  if (lowerName === 'makefile' || lowerName === 'gnumakefile') return 'makefile'
-  if (lowerName === '.bashrc' || lowerName === '.zshrc' || lowerName === '.profile') return 'bash'
-
-  const ext = fileName.includes('.') ? fileName.split('.').pop()! : ''
-  return EXT_TO_LANG[ext] || null
 }
 
 const terminalStyle: React.CSSProperties = {

--- a/src/renderer/src/utils/format-utils.ts
+++ b/src/renderer/src/utils/format-utils.ts
@@ -1,0 +1,16 @@
+/**
+ * Pure number/string formatting utilities.
+ * Extracted from StatusBar for testability.
+ */
+
+export function formatNum(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`
+  return n.toLocaleString()
+}
+
+export function formatTokens(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`
+  return String(n)
+}

--- a/src/renderer/src/utils/project-utils.ts
+++ b/src/renderer/src/utils/project-utils.ts
@@ -1,0 +1,48 @@
+/**
+ * Pure utility functions for project sorting and activity levels.
+ * Extracted from ProjectList for testability.
+ */
+
+export type ProjectSortOrder = 'alpha' | 'recent' | 'sessions'
+
+export interface ProjectData {
+  name: string
+  encodedName: string
+  sessionCount: number
+  lastModified: number
+}
+
+export function sortProjects<T extends ProjectData>(projects: T[], order: ProjectSortOrder): T[] {
+  const sorted = [...projects]
+  switch (order) {
+    case 'alpha':
+      return sorted.sort((a, b) => a.name.localeCompare(b.name))
+    case 'recent':
+      return sorted.sort((a, b) => b.lastModified - a.lastModified)
+    case 'sessions':
+      return sorted.sort((a, b) => b.sessionCount - a.sessionCount)
+  }
+}
+
+export function getActivityLevel(timestamp: number): 'active' | 'recent' | 'stale' {
+  if (!timestamp) return 'stale'
+  const diff = Date.now() - timestamp
+  if (diff < 60_000) return 'active'
+  if (diff < 300_000) return 'recent'
+  return 'stale'
+}
+
+export function formatRelativeTime(timestamp: number): string {
+  if (!timestamp) return 'Never'
+  const now = Date.now()
+  const diff = now - timestamp
+  const minutes = Math.floor(diff / 60000)
+  if (minutes < 1) return 'Just now'
+  if (minutes < 60) return `${minutes}m ago`
+  const hours = Math.floor(minutes / 60)
+  if (hours < 24) return `${hours}h ago`
+  const days = Math.floor(hours / 24)
+  if (days < 7) return `${days}d ago`
+  const date = new Date(timestamp)
+  return date.toLocaleDateString(undefined, { day: 'numeric', month: 'short', year: date.getFullYear() !== new Date().getFullYear() ? 'numeric' : undefined })
+}

--- a/src/renderer/src/utils/session-utils.ts
+++ b/src/renderer/src/utils/session-utils.ts
@@ -1,0 +1,37 @@
+/**
+ * Pure utility functions for session status detection.
+ * Extracted from SessionList for testability.
+ */
+
+export type SessionStatus = 'active' | 'recent' | 'stale'
+
+export function getSessionStatus(lastModified: number): SessionStatus {
+  const now = Date.now()
+  const diff = now - lastModified
+  if (diff < 60 * 1000) return 'active'
+  if (diff < 5 * 60 * 1000) return 'recent'
+  return 'stale'
+}
+
+export function getStatusBadge(status: SessionStatus): { icon: string; variant: 'success' | 'info' | 'secondary' } {
+  switch (status) {
+    case 'active': return { icon: '🟢', variant: 'success' }
+    case 'recent': return { icon: '🔵', variant: 'info' }
+    case 'stale': return { icon: '⚪', variant: 'secondary' }
+  }
+}
+
+export function formatDateTime(timestamp: number): string {
+  const date = new Date(timestamp)
+  const now = new Date()
+  const isToday = date.toDateString() === now.toDateString()
+  const yesterday = new Date(now)
+  yesterday.setDate(yesterday.getDate() - 1)
+  const isYesterday = date.toDateString() === yesterday.toDateString()
+
+  const time = date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+
+  if (isToday) return `Today ${time}`
+  if (isYesterday) return `Yesterday ${time}`
+  return date.toLocaleDateString([], { month: 'short', day: 'numeric' }) + ` ${time}`
+}

--- a/src/renderer/src/utils/tool-formatting.ts
+++ b/src/renderer/src/utils/tool-formatting.ts
@@ -1,0 +1,127 @@
+/**
+ * Pure utility functions for tool name formatting and parsing.
+ * Extracted from ToolCallCard for testability.
+ */
+
+export const TOOL_ICONS: Record<string, string> = {
+  Read: '📄',
+  Write: '✏️',
+  Edit: '🔧',
+  Bash: '💻',
+  Grep: '🔍',
+  Glob: '📁',
+  WebSearch: '🌐',
+  WebFetch: '🌐',
+  Task: '📋',
+  AskUserQuestion: '❓',
+  NotebookEdit: '📓',
+  TodoWrite: '✅',
+  // MCP server tools
+  take_screenshot: '📸',
+  take_snapshot: '🌲',
+  navigate_page: '🧭',
+  click: '🖱️',
+  fill: '⌨️',
+  fill_form: '📝',
+  evaluate_script: '⚡',
+  list_pages: '📑',
+  list_network_requests: '🌐',
+  list_console_messages: '🖥️',
+  get_network_request: '📡',
+  get_console_message: '💬',
+  hover: '🖱️',
+  press_key: '⌨️',
+  wait_for: '⏳',
+  handle_dialog: '💬',
+  performance_start_trace: '⏱️',
+  performance_stop_trace: '⏹️',
+  upload_file: '📤',
+}
+
+/** Format a tool name for display — handles MCP double-underscore names */
+export function formatToolName(rawName: string): { icon: string; label: string; server?: string } {
+  const icon = TOOL_ICONS[rawName] || '🔧'
+
+  // MCP tools: mcp__server-name__tool_name
+  if (rawName.includes('__')) {
+    const parts = rawName.split('__')
+    if (parts.length >= 3) {
+      const server = parts[1]
+      const tool = parts.slice(2).join('__')
+      const toolIcon = TOOL_ICONS[tool] || icon
+      // Convert snake_case to readable label
+      const label = tool.replace(/_/g, ' ')
+      return { icon: toolIcon, label, server }
+    }
+  }
+
+  return { icon, label: rawName }
+}
+
+export interface ParsedResult {
+  mainContent: string
+  systemReminders: string[]
+}
+
+/** Parse out <system-reminder> tags from result text */
+export function parseSystemReminders(text: string): ParsedResult {
+  const systemReminders: string[] = []
+  const reminderRegex = /<system-reminder>([\s\S]*?)<\/system-reminder>/g
+
+  let match
+  let lastIndex = 0
+  const contentParts: string[] = []
+
+  while ((match = reminderRegex.exec(text)) !== null) {
+    // Add content before this reminder
+    contentParts.push(text.slice(lastIndex, match.index))
+    // Store the reminder content
+    systemReminders.push(match[1].trim())
+    lastIndex = match.index + match[0].length
+  }
+
+  // Add any remaining content after the last reminder
+  contentParts.push(text.slice(lastIndex))
+
+  const mainContent = contentParts.join('').trim()
+
+  return { mainContent, systemReminders }
+}
+
+/** Map file extensions to highlight.js language names */
+export const EXT_TO_LANG: Record<string, string> = {
+  js: 'javascript', jsx: 'javascript', mjs: 'javascript', cjs: 'javascript',
+  ts: 'typescript', tsx: 'typescript', mts: 'typescript',
+  py: 'python', rb: 'ruby', rs: 'rust', go: 'go',
+  java: 'java', kt: 'kotlin', scala: 'scala',
+  c: 'c', h: 'c', cpp: 'cpp', cc: 'cpp', cxx: 'cpp', hpp: 'cpp',
+  cs: 'csharp', swift: 'swift', m: 'objectivec',
+  sh: 'bash', bash: 'bash', zsh: 'bash', fish: 'shell',
+  html: 'xml', htm: 'xml', xml: 'xml', svg: 'xml', xsl: 'xml',
+  css: 'css', scss: 'scss', sass: 'scss', less: 'less',
+  json: 'json', yaml: 'yaml', yml: 'yaml', toml: 'ini',
+  md: 'markdown', markdown: 'markdown',
+  sql: 'sql', graphql: 'graphql', gql: 'graphql',
+  dockerfile: 'dockerfile', docker: 'dockerfile',
+  makefile: 'makefile', cmake: 'cmake',
+  lua: 'lua', perl: 'perl', pl: 'perl', php: 'php',
+  r: 'r', R: 'r', jl: 'julia',
+  hs: 'haskell', erl: 'erlang', ex: 'elixir', exs: 'elixir',
+  clj: 'clojure', lisp: 'lisp', el: 'lisp',
+  vim: 'vim', ini: 'ini', conf: 'ini', cfg: 'ini',
+  tf: 'hcl', hcl: 'hcl',
+  proto: 'protobuf', ps1: 'powershell',
+  diff: 'diff', patch: 'diff'
+}
+
+export function getLangFromPath(filePath: string): string | null {
+  const fileName = filePath.split('/').pop() || ''
+  // Handle extensionless names like Dockerfile, Makefile
+  const lowerName = fileName.toLowerCase()
+  if (lowerName === 'dockerfile') return 'dockerfile'
+  if (lowerName === 'makefile' || lowerName === 'gnumakefile') return 'makefile'
+  if (lowerName === '.bashrc' || lowerName === '.zshrc' || lowerName === '.profile') return 'bash'
+
+  const ext = fileName.includes('.') ? fileName.split('.').pop()! : ''
+  return EXT_TO_LANG[ext] || null
+}

--- a/tests/e2e/message-stream.spec.ts
+++ b/tests/e2e/message-stream.spec.ts
@@ -56,9 +56,9 @@ test.describe('Message Stream', () => {
       const toolCount = await toolCards.count()
       expect(toolCount).toBeGreaterThan(0)
 
-      // Should show token usage bar
-      const tokenBar = window.locator('[data-testid="token-usage-bar"]')
-      await expect(tokenBar).toBeVisible()
+      // Should show status bar (replaced TokenUsageBar)
+      const statusBar = window.locator('[data-testid="status-bar"]')
+      await expect(statusBar).toBeVisible()
 
     } finally {
       if (app) {

--- a/tests/e2e/project-discovery.spec.ts
+++ b/tests/e2e/project-discovery.spec.ts
@@ -34,7 +34,7 @@ test.describe('Project Discovery', () => {
       await expect(projectItem).toBeVisible()
 
       // Project should show session count badge
-      const badge = projectItem.locator('.badge')
+      const badge = projectItem.locator('.ui-badge')
       await expect(badge).toBeVisible()
       const count = await badge.textContent()
       expect(parseInt(count || '0')).toBeGreaterThan(0)
@@ -77,15 +77,19 @@ test.describe('Project Discovery', () => {
       const count = await sessionItems.count()
       expect(count).toBeGreaterThan(0)
 
-      // Should have different session types
+      // Should have main sessions visible at top level
       const mainSessions = window.locator('[data-testid^="session-main-"]')
-      const subagentSessions = window.locator('[data-testid^="session-subagent-"]')
-
       const mainCount = await mainSessions.count()
-      const subagentCount = await subagentSessions.count()
-
-      // We know our fixture has both main sessions and subagents
       expect(mainCount).toBeGreaterThan(0)
+
+      // Expand the parent session that has subagents (session-ac1708b5)
+      const subToggle = window.locator('.session-item__sub-toggle').first()
+      await subToggle.click()
+
+      // After expanding, subagent sessions should be visible
+      const subagentSessions = window.locator('[data-testid^="session-subagent-"]')
+      await expect(subagentSessions.first()).toBeVisible({ timeout: 3000 })
+      const subagentCount = await subagentSessions.count()
       expect(subagentCount).toBeGreaterThan(0)
 
     } finally {

--- a/tests/e2e/theme-toggle.spec.ts
+++ b/tests/e2e/theme-toggle.spec.ts
@@ -1,0 +1,76 @@
+import { test, expect, _electron as electron } from '@playwright/test'
+import path from 'path'
+
+test.describe('Theme Toggle', () => {
+  test('shows theme toggle with light/system/dark buttons', async () => {
+    let app
+    try {
+      app = await electron.launch({
+        args: [path.join(__dirname, '../../out/main/index.js')],
+      })
+
+      const window = await app.firstWindow()
+      await window.waitForLoadState('domcontentloaded')
+
+      // Wait for the theme toggle to appear
+      const themeToggle = window.locator('[data-testid="theme-toggle"]')
+      await expect(themeToggle).toBeVisible({ timeout: 5000 })
+
+      // Should have three theme buttons
+      const lightBtn = window.locator('[data-testid="theme-light"]')
+      const systemBtn = window.locator('[data-testid="theme-system"]')
+      const darkBtn = window.locator('[data-testid="theme-dark"]')
+
+      await expect(lightBtn).toBeVisible()
+      await expect(systemBtn).toBeVisible()
+      await expect(darkBtn).toBeVisible()
+
+      // System should be the default active mode
+      await expect(systemBtn).toHaveClass(/theme-toggle__btn--active/)
+
+    } finally {
+      if (app) {
+        await app.close()
+      }
+    }
+  })
+
+  test('switches theme and applies data-theme attribute', async () => {
+    let app
+    try {
+      app = await electron.launch({
+        args: [path.join(__dirname, '../../out/main/index.js')],
+      })
+
+      const window = await app.firstWindow()
+      await window.waitForLoadState('domcontentloaded')
+      await window.waitForSelector('[data-testid="theme-toggle"]', { timeout: 5000 })
+
+      // Click dark theme
+      await window.click('[data-testid="theme-dark"]')
+
+      // Verify data-theme attribute is set on html element
+      const theme = await window.evaluate(() => document.documentElement.getAttribute('data-theme'))
+      expect(theme).toBe('dark')
+
+      // Click light theme
+      await window.click('[data-testid="theme-light"]')
+
+      const lightTheme = await window.evaluate(() => document.documentElement.getAttribute('data-theme'))
+      expect(lightTheme).toBe('light')
+
+      // Dark button should no longer be active
+      const darkBtn = window.locator('[data-testid="theme-dark"]')
+      await expect(darkBtn).not.toHaveClass(/theme-toggle__btn--active/)
+
+      // Light button should be active
+      const lightBtn = window.locator('[data-testid="theme-light"]')
+      await expect(lightBtn).toHaveClass(/theme-toggle__btn--active/)
+
+    } finally {
+      if (app) {
+        await app.close()
+      }
+    }
+  })
+})

--- a/tests/e2e/theme-toggle.spec.ts
+++ b/tests/e2e/theme-toggle.spec.ts
@@ -12,9 +12,12 @@ test.describe('Theme Toggle', () => {
       const window = await app.firstWindow()
       await window.waitForLoadState('domcontentloaded')
 
-      // Wait for the theme toggle to appear
+      // Wait for the app panels to render first
+      await window.waitForSelector('[data-testid="project-sidebar"]', { timeout: 10000 })
+
+      // Theme toggle should be visible in all states (including empty project list)
       const themeToggle = window.locator('[data-testid="theme-toggle"]')
-      await expect(themeToggle).toBeVisible({ timeout: 5000 })
+      await expect(themeToggle).toBeVisible({ timeout: 10000 })
 
       // Should have three theme buttons
       const lightBtn = window.locator('[data-testid="theme-light"]')
@@ -44,7 +47,10 @@ test.describe('Theme Toggle', () => {
 
       const window = await app.firstWindow()
       await window.waitForLoadState('domcontentloaded')
-      await window.waitForSelector('[data-testid="theme-toggle"]', { timeout: 5000 })
+
+      // Wait for the app panels to render first
+      await window.waitForSelector('[data-testid="project-sidebar"]', { timeout: 10000 })
+      await window.waitForSelector('[data-testid="theme-toggle"]', { timeout: 10000 })
 
       // Click dark theme
       await window.click('[data-testid="theme-dark"]')

--- a/tests/unit/renderer/format-utils.test.ts
+++ b/tests/unit/renderer/format-utils.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest'
+import { formatNum, formatTokens } from '@renderer/utils/format-utils'
+
+describe('Format Utils', () => {
+  describe('formatNum', () => {
+    it('formats small numbers with locale string', () => {
+      expect(formatNum(42)).toBe('42')
+    })
+
+    it('formats thousands with k suffix', () => {
+      expect(formatNum(1_500)).toBe('1.5k')
+    })
+
+    it('formats exact thousand', () => {
+      expect(formatNum(1_000)).toBe('1.0k')
+    })
+
+    it('formats millions with M suffix', () => {
+      expect(formatNum(2_500_000)).toBe('2.5M')
+    })
+
+    it('formats exact million', () => {
+      expect(formatNum(1_000_000)).toBe('1.0M')
+    })
+
+    it('formats zero', () => {
+      expect(formatNum(0)).toBe('0')
+    })
+
+    it('formats 999 without suffix', () => {
+      expect(formatNum(999)).toBe('999')
+    })
+
+    it('formats large thousands', () => {
+      expect(formatNum(150_000)).toBe('150.0k')
+    })
+
+    it('rounds to one decimal place for k', () => {
+      expect(formatNum(1_234)).toBe('1.2k')
+    })
+
+    it('rounds to one decimal place for M', () => {
+      expect(formatNum(1_234_567)).toBe('1.2M')
+    })
+  })
+
+  describe('formatTokens', () => {
+    it('formats small numbers as plain string', () => {
+      expect(formatTokens(42)).toBe('42')
+    })
+
+    it('formats thousands with k suffix', () => {
+      expect(formatTokens(1_500)).toBe('1.5k')
+    })
+
+    it('formats millions with M suffix', () => {
+      expect(formatTokens(2_500_000)).toBe('2.5M')
+    })
+
+    it('formats zero', () => {
+      expect(formatTokens(0)).toBe('0')
+    })
+
+    it('returns string type for small numbers', () => {
+      const result = formatTokens(100)
+      expect(typeof result).toBe('string')
+      expect(result).toBe('100')
+    })
+  })
+})

--- a/tests/unit/renderer/project-utils.test.ts
+++ b/tests/unit/renderer/project-utils.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { sortProjects, getActivityLevel, formatRelativeTime } from '@renderer/utils/project-utils'
+
+function makeProject(overrides: Partial<{ name: string; encodedName: string; sessionCount: number; lastModified: number }> = {}) {
+  return {
+    name: overrides.name ?? 'test-project',
+    encodedName: overrides.encodedName ?? 'test-project',
+    sessionCount: overrides.sessionCount ?? 5,
+    lastModified: overrides.lastModified ?? Date.now()
+  }
+}
+
+describe('Project Utils', () => {
+  describe('sortProjects', () => {
+    const projects = [
+      makeProject({ name: 'Charlie', encodedName: 'charlie', sessionCount: 3, lastModified: 1000 }),
+      makeProject({ name: 'Alpha', encodedName: 'alpha', sessionCount: 10, lastModified: 3000 }),
+      makeProject({ name: 'Bravo', encodedName: 'bravo', sessionCount: 1, lastModified: 2000 })
+    ]
+
+    it('sorts alphabetically by name', () => {
+      const sorted = sortProjects(projects, 'alpha')
+      expect(sorted.map(p => p.name)).toEqual(['Alpha', 'Bravo', 'Charlie'])
+    })
+
+    it('sorts by most recent first', () => {
+      const sorted = sortProjects(projects, 'recent')
+      expect(sorted.map(p => p.name)).toEqual(['Alpha', 'Bravo', 'Charlie'])
+    })
+
+    it('sorts by session count descending', () => {
+      const sorted = sortProjects(projects, 'sessions')
+      expect(sorted.map(p => p.name)).toEqual(['Alpha', 'Charlie', 'Bravo'])
+    })
+
+    it('does not mutate the original array', () => {
+      const original = [...projects]
+      sortProjects(projects, 'alpha')
+      expect(projects).toEqual(original)
+    })
+
+    it('handles empty array', () => {
+      expect(sortProjects([], 'alpha')).toEqual([])
+    })
+
+    it('handles single item', () => {
+      const single = [makeProject({ name: 'Solo' })]
+      expect(sortProjects(single, 'recent')).toHaveLength(1)
+    })
+  })
+
+  describe('getActivityLevel', () => {
+    beforeEach(() => {
+      vi.useFakeTimers()
+      vi.setSystemTime(new Date('2026-02-17T12:00:00.000Z'))
+    })
+
+    afterEach(() => {
+      vi.useRealTimers()
+    })
+
+    it('returns "active" for timestamps less than 1 minute old', () => {
+      const recent = Date.now() - 30_000 // 30 seconds ago
+      expect(getActivityLevel(recent)).toBe('active')
+    })
+
+    it('returns "recent" for timestamps 1-5 minutes old', () => {
+      const twoMinAgo = Date.now() - 120_000 // 2 minutes ago
+      expect(getActivityLevel(twoMinAgo)).toBe('recent')
+    })
+
+    it('returns "stale" for timestamps older than 5 minutes', () => {
+      const tenMinAgo = Date.now() - 600_000 // 10 minutes ago
+      expect(getActivityLevel(tenMinAgo)).toBe('stale')
+    })
+
+    it('returns "stale" for zero timestamp', () => {
+      expect(getActivityLevel(0)).toBe('stale')
+    })
+
+    it('returns "active" at exactly now', () => {
+      expect(getActivityLevel(Date.now())).toBe('active')
+    })
+
+    it('returns "recent" at exactly 1 minute boundary', () => {
+      const oneMinAgo = Date.now() - 60_000
+      expect(getActivityLevel(oneMinAgo)).toBe('recent')
+    })
+
+    it('returns "stale" at exactly 5 minute boundary', () => {
+      const fiveMinAgo = Date.now() - 300_000
+      expect(getActivityLevel(fiveMinAgo)).toBe('stale')
+    })
+  })
+
+  describe('formatRelativeTime', () => {
+    beforeEach(() => {
+      vi.useFakeTimers()
+      vi.setSystemTime(new Date('2026-02-17T12:00:00.000Z'))
+    })
+
+    afterEach(() => {
+      vi.useRealTimers()
+    })
+
+    it('returns "Never" for zero timestamp', () => {
+      expect(formatRelativeTime(0)).toBe('Never')
+    })
+
+    it('returns "Just now" for very recent timestamps', () => {
+      expect(formatRelativeTime(Date.now() - 10_000)).toBe('Just now')
+    })
+
+    it('returns minutes for recent timestamps', () => {
+      expect(formatRelativeTime(Date.now() - 180_000)).toBe('3m ago')
+    })
+
+    it('returns hours for older timestamps', () => {
+      expect(formatRelativeTime(Date.now() - 7_200_000)).toBe('2h ago')
+    })
+
+    it('returns days for multi-day timestamps', () => {
+      expect(formatRelativeTime(Date.now() - 172_800_000)).toBe('2d ago')
+    })
+
+    it('returns formatted date for timestamps older than a week', () => {
+      const twoWeeksAgo = Date.now() - 14 * 24 * 60 * 60 * 1000
+      const result = formatRelativeTime(twoWeeksAgo)
+      // Should contain a month and day
+      expect(result).toMatch(/\d/)
+      expect(result).not.toContain('ago')
+    })
+  })
+})

--- a/tests/unit/renderer/session-utils.test.ts
+++ b/tests/unit/renderer/session-utils.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { getSessionStatus, getStatusBadge, formatDateTime } from '@renderer/utils/session-utils'
+
+describe('Session Utils', () => {
+  describe('getSessionStatus', () => {
+    beforeEach(() => {
+      vi.useFakeTimers()
+      vi.setSystemTime(new Date('2026-02-17T12:00:00.000Z'))
+    })
+
+    afterEach(() => {
+      vi.useRealTimers()
+    })
+
+    it('returns "active" for < 1 minute old', () => {
+      expect(getSessionStatus(Date.now() - 30_000)).toBe('active')
+    })
+
+    it('returns "recent" for 1-5 minutes old', () => {
+      expect(getSessionStatus(Date.now() - 180_000)).toBe('recent')
+    })
+
+    it('returns "stale" for > 5 minutes old', () => {
+      expect(getSessionStatus(Date.now() - 600_000)).toBe('stale')
+    })
+
+    it('returns "active" at exactly now', () => {
+      expect(getSessionStatus(Date.now())).toBe('active')
+    })
+
+    it('returns "stale" for very old timestamps', () => {
+      expect(getSessionStatus(Date.now() - 86_400_000)).toBe('stale')
+    })
+  })
+
+  describe('getStatusBadge', () => {
+    it('returns green for active', () => {
+      const badge = getStatusBadge('active')
+      expect(badge.icon).toBe('🟢')
+      expect(badge.variant).toBe('success')
+    })
+
+    it('returns blue for recent', () => {
+      const badge = getStatusBadge('recent')
+      expect(badge.icon).toBe('🔵')
+      expect(badge.variant).toBe('info')
+    })
+
+    it('returns gray for stale', () => {
+      const badge = getStatusBadge('stale')
+      expect(badge.icon).toBe('⚪')
+      expect(badge.variant).toBe('secondary')
+    })
+  })
+
+  describe('formatDateTime', () => {
+    beforeEach(() => {
+      vi.useFakeTimers()
+      vi.setSystemTime(new Date('2026-02-17T12:00:00.000Z'))
+    })
+
+    afterEach(() => {
+      vi.useRealTimers()
+    })
+
+    it('shows "Today" for timestamps from today', () => {
+      const today = Date.now() - 3600_000 // 1 hour ago
+      expect(formatDateTime(today)).toMatch(/^Today/)
+    })
+
+    it('shows "Yesterday" for timestamps from yesterday', () => {
+      const yesterday = Date.now() - 86_400_000 // 24 hours ago
+      expect(formatDateTime(yesterday)).toMatch(/^Yesterday/)
+    })
+
+    it('shows month and day for older timestamps', () => {
+      const oldDate = new Date('2026-02-10T10:00:00.000Z').getTime()
+      const result = formatDateTime(oldDate)
+      expect(result).toMatch(/Feb/)
+    })
+
+    it('includes time component', () => {
+      const result = formatDateTime(Date.now())
+      // Time should contain digits and colon (e.g., "12:00")
+      expect(result).toMatch(/\d{1,2}:\d{2}/)
+    })
+  })
+})

--- a/tests/unit/renderer/tool-formatting.test.ts
+++ b/tests/unit/renderer/tool-formatting.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect } from 'vitest'
+import { formatToolName, parseSystemReminders, getLangFromPath, TOOL_ICONS } from '@renderer/utils/tool-formatting'
+
+describe('Tool Formatting', () => {
+  describe('formatToolName', () => {
+    it('returns known icon and label for built-in tools', () => {
+      const result = formatToolName('Read')
+      expect(result.icon).toBe('📄')
+      expect(result.label).toBe('Read')
+      expect(result.server).toBeUndefined()
+    })
+
+    it('returns default icon for unknown tools', () => {
+      const result = formatToolName('UnknownTool')
+      expect(result.icon).toBe('🔧')
+      expect(result.label).toBe('UnknownTool')
+    })
+
+    it('parses MCP tool names with server prefix', () => {
+      const result = formatToolName('mcp__chrome-devtools__take_screenshot')
+      expect(result.server).toBe('chrome-devtools')
+      expect(result.label).toBe('take screenshot')
+      expect(result.icon).toBe('📸') // Known MCP tool
+    })
+
+    it('uses tool-specific icon for MCP tools when known', () => {
+      const result = formatToolName('mcp__some-server__evaluate_script')
+      expect(result.icon).toBe('⚡')
+      expect(result.server).toBe('some-server')
+    })
+
+    it('handles MCP tools with unknown tool names', () => {
+      const result = formatToolName('mcp__my-server__custom_tool')
+      expect(result.server).toBe('my-server')
+      expect(result.label).toBe('custom tool')
+      expect(result.icon).toBe('🔧') // Fallback
+    })
+
+    it('handles double underscores in tool name portion', () => {
+      const result = formatToolName('mcp__server__tool__with__extra')
+      expect(result.server).toBe('server')
+      // All underscores (including double) get replaced with spaces
+      expect(result.label).toBe('tool  with  extra')
+    })
+
+    it('treats single __ as non-MCP if fewer than 3 parts', () => {
+      const result = formatToolName('not__mcp')
+      // Only 2 parts, so treated as plain tool
+      expect(result.server).toBeUndefined()
+      expect(result.label).toBe('not__mcp')
+    })
+
+    it('returns correct icons for all standard Claude tools', () => {
+      const expectedTools = ['Read', 'Write', 'Edit', 'Bash', 'Grep', 'Glob', 'WebSearch', 'WebFetch', 'Task', 'AskUserQuestion']
+      for (const tool of expectedTools) {
+        const result = formatToolName(tool)
+        expect(TOOL_ICONS[tool]).toBeDefined()
+        expect(result.label).toBe(tool)
+      }
+    })
+  })
+
+  describe('parseSystemReminders', () => {
+    it('returns text as-is when no reminders present', () => {
+      const result = parseSystemReminders('Hello world')
+      expect(result.mainContent).toBe('Hello world')
+      expect(result.systemReminders).toHaveLength(0)
+    })
+
+    it('extracts a single system reminder', () => {
+      const input = 'Before <system-reminder>Remember this</system-reminder> After'
+      const result = parseSystemReminders(input)
+      expect(result.mainContent).toBe('Before  After')
+      expect(result.systemReminders).toEqual(['Remember this'])
+    })
+
+    it('extracts multiple system reminders', () => {
+      const input = 'Start <system-reminder>First</system-reminder> middle <system-reminder>Second</system-reminder> end'
+      const result = parseSystemReminders(input)
+      expect(result.mainContent).toBe('Start  middle  end')
+      expect(result.systemReminders).toEqual(['First', 'Second'])
+    })
+
+    it('handles multiline reminder content', () => {
+      const input = 'Text <system-reminder>\nLine 1\nLine 2\n</system-reminder> more'
+      const result = parseSystemReminders(input)
+      expect(result.systemReminders).toEqual(['Line 1\nLine 2'])
+    })
+
+    it('returns empty mainContent when text is only reminders', () => {
+      const input = '<system-reminder>Only reminder</system-reminder>'
+      const result = parseSystemReminders(input)
+      expect(result.mainContent).toBe('')
+      expect(result.systemReminders).toEqual(['Only reminder'])
+    })
+
+    it('handles empty string input', () => {
+      const result = parseSystemReminders('')
+      expect(result.mainContent).toBe('')
+      expect(result.systemReminders).toHaveLength(0)
+    })
+
+    it('trims whitespace from reminder content', () => {
+      const input = '<system-reminder>  spaced  </system-reminder>'
+      const result = parseSystemReminders(input)
+      expect(result.systemReminders).toEqual(['spaced'])
+    })
+  })
+
+  describe('getLangFromPath', () => {
+    it('returns typescript for .ts files', () => {
+      expect(getLangFromPath('/src/main.ts')).toBe('typescript')
+    })
+
+    it('returns typescript for .tsx files', () => {
+      expect(getLangFromPath('/src/App.tsx')).toBe('typescript')
+    })
+
+    it('returns javascript for .js files', () => {
+      expect(getLangFromPath('/lib/index.js')).toBe('javascript')
+    })
+
+    it('returns python for .py files', () => {
+      expect(getLangFromPath('/scripts/run.py')).toBe('python')
+    })
+
+    it('returns bash for shell files', () => {
+      expect(getLangFromPath('/scripts/deploy.sh')).toBe('bash')
+    })
+
+    it('returns dockerfile for Dockerfile', () => {
+      expect(getLangFromPath('/project/Dockerfile')).toBe('dockerfile')
+    })
+
+    it('returns makefile for Makefile', () => {
+      expect(getLangFromPath('/project/Makefile')).toBe('makefile')
+    })
+
+    it('returns bash for .bashrc', () => {
+      expect(getLangFromPath('/home/user/.bashrc')).toBe('bash')
+    })
+
+    it('returns null for unknown extensions', () => {
+      expect(getLangFromPath('/file.xyz')).toBeNull()
+    })
+
+    it('returns null for extensionless files (non-special)', () => {
+      expect(getLangFromPath('/some/randomfile')).toBeNull()
+    })
+
+    it('handles deeply nested paths', () => {
+      expect(getLangFromPath('/a/b/c/d/e/component.tsx')).toBe('typescript')
+    })
+
+    it('returns json for .json files', () => {
+      expect(getLangFromPath('package.json')).toBe('json')
+    })
+
+    it('returns yaml for .yml files', () => {
+      expect(getLangFromPath('.github/workflows/ci.yml')).toBe('yaml')
+    })
+
+    it('returns css for .css files', () => {
+      expect(getLangFromPath('styles/main.css')).toBe('css')
+    })
+
+    it('returns scss for .scss files', () => {
+      expect(getLangFromPath('styles/theme.scss')).toBe('scss')
+    })
+
+    it('returns rust for .rs files', () => {
+      expect(getLangFromPath('src/main.rs')).toBe('rust')
+    })
+
+    it('returns go for .go files', () => {
+      expect(getLangFromPath('cmd/server/main.go')).toBe('go')
+    })
+  })
+
+  describe('TOOL_ICONS', () => {
+    it('has icons for all MCP chrome-devtools tools', () => {
+      const mcpTools = [
+        'take_screenshot', 'take_snapshot', 'navigate_page', 'click',
+        'fill', 'fill_form', 'evaluate_script', 'list_pages',
+        'list_network_requests', 'list_console_messages'
+      ]
+      for (const tool of mcpTools) {
+        expect(TOOL_ICONS[tool]).toBeDefined()
+      }
+    })
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'node',
+    exclude: ['tests/e2e/**', 'node_modules/**'],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html'],


### PR DESCRIPTION
## Summary

- **Fix vitest picking up Playwright e2e specs** — added `tests/e2e/**` to vitest exclude config, resolving 4 local test failures
- **Fix 3 CI e2e failures** — updated `.badge` → `.ui-badge` selector (Radix migration), `token-usage-bar` → `status-bar` testid (StatusBar replacement), and expanded parent before checking subagent count (Radix Collapsible)
- **Extract pure utilities** from renderer components into `src/renderer/src/utils/` for testability without React deps
- **Add 79 new unit tests** covering tool formatting (MCP names, icons), system-reminder parsing, project sorting/activity levels, session status, and number formatting
- **Add e2e tests for theme toggle** — verifies light/system/dark buttons, default mode, and data-theme attribute switching
- **Add data-testid attributes** to ThemeToggle component for testability

## Test plan

- [x] All 160 unit/integration tests pass locally (`npx vitest run`)
- [ ] CI passes on push (unit, integration, and e2e)
- [ ] Theme toggle e2e test works in CI Playwright

🤖 Generated with [Claude Code](https://claude.com/claude-code)